### PR TITLE
Pod deployment patch

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Refresh visit-service pods
         run: |
           echo "Setting an envinronment variable in the deployment service causes the pods to redeploy, forcing the pods to pull the latest image"
-          kubectl set env deployment visits-service-java -n default REDEPOLY_ID=${{ env.ACTION_ID }}
+          kubectl set env deployment visits-service-java -n default REDEPLOY_ID=${{ env.ACTION_ID }}
       
       - name: Upload Application Topology Files to S3
         run: |          

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -16,6 +16,7 @@ env: # hard-code resource names
   TOPOLOGY_BUCKET: cicd-topology-61d64816-cffc-40b9-88b2-e4d6c101b034
   AWS_EXECUTION_ENV: ${{ github.repository }}/actions/run/${{ github.run_id }}/${{ github.job }}
   TF_VAR_isengard_admin_role_arn: ${{ secrets.ISENGARD_ADMIN_ROLE_ARN }}
+  ACTION_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
 permissions:
   id-token: write
@@ -136,6 +137,10 @@ jobs:
       - name: Run kubectl commands
         run: |
           ./scripts/eks/appsignals/tf-deploy-k8s-res.sh
+      - name: Refresh visit-service pods
+        run: |
+          echo "Setting an envinronment variable in the deployment service causes the pods to redeploy, forcing the pods to pull the latest image"
+          kubectl set env deployment visits-service-java -n default REDEPOLY_ID=${{ env.ACTION_ID }}
       
       - name: Upload Application Topology Files to S3
         run: |          


### PR DESCRIPTION
Adding an environment variable to the deployment template will tear down and recreate all of the associated pods (with a rollout strategy so there should not be outages). This is an important deployment step for us because the pods currently do not pull the latest image from ECR since they are running. When we update the `visit-service` image, this step forces the pods to pull the current image with the `latest` tag.

This step adds a unique id - taken from the github action run - as an environment variable for the `visits-service` deployment so that only the visits service pods are updated. 